### PR TITLE
docs: improve readme usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const isValid = validateDDD(41); // true
 // commonjs = const isValid = validateBrazilianDDD.validateDDD(41);
 
 // with string value
-const isValid = validateDDD('40'); // false
+const isValid = validateDDD('41'); // true
 // commonjs = const isValid = validateBrazilianDDD.validateDDD('40');
 
 // or with a phone number - it must be provided within a mask to work!


### PR DESCRIPTION
#### What is the goal of this change?
Improve `readme` usage for _int_ and _string_ values. It seemed that using string values would return _false_ always, but you can use `41` or `"41"`.

#### Is there any issue related?
N/A

#### How does the changes address the issue?
(answer here)
